### PR TITLE
Timestamp-based custom ID

### DIFF
--- a/impl/src/main/kotlin/com/dah/nrs/Bandori.kt
+++ b/impl/src/main/kotlin/com/dah/nrs/Bandori.kt
@@ -162,7 +162,7 @@ fun DSLScope.Bandori() {
 
             Contains(MusicVocalImageContainFactor) {
                 Contains("M-VGMDB-AL-106577-6")
-                Contains("M-35", 1.0 / 3)
+                Contains("M-20220130T183728-4", 1.0 / 3)
             }
         }
 
@@ -218,7 +218,7 @@ fun DSLScope.Bandori() {
                 Music(0.25)
                 OsuSong(personal = 0.5)
 
-                Remix("M-35")
+                Remix("M-20220130T183728-4")
             }
         }
 
@@ -309,7 +309,7 @@ fun DSLScope.Bandori() {
         title = "SILENT SIREN" // generated(fill_music_metadata.dart v0.1.1)
 
         Entry {
-            id = "M-32"
+            id = "M-20220130T183728-1"
             title = "S"
             ValidatorSuppress("dah-entry-no-consumed")
 
@@ -317,7 +317,7 @@ fun DSLScope.Bandori() {
             Visual(VisualKind.AlbumArt, 0.1, 0.15)
 
             Entry {
-                id = "M-33"
+                id = "M-20220130T183728-2"
                 title = "Cherry Bomb"
 
                 // Length source: https://open.spotify.com/track/5KhTHcY2WuCHy21jhxTFAP
@@ -349,7 +349,7 @@ fun DSLScope.Bandori() {
     }
 
     Entry {
-        id = "M-35"
+        id = "M-20220130T183728-4"
         title = "Harumodoki (Asterisk DnB Remix) [Rakakun- Edit]"
 
         // Length source: https://osu.ppy.sh/beatmapsets/1034608#osu/2163138

--- a/impl/src/main/kotlin/com/dah/nrs/CommonArtists.kt
+++ b/impl/src/main/kotlin/com/dah/nrs/CommonArtists.kt
@@ -7,29 +7,30 @@ import com.dah.nrs.exts.*
 
 fun DSLScope.CommonArtists() {
     Entry {
-        id = "M-1"
+        // "Initial commit" - 2022-01-13T15:42:28Z
+        id = "M-20220113T154228"
         title = "Asterisk"
         ValidatorSuppress("dah-entry-no-consumed")
 
-        Contains("M-35", 1.0 / 3)
-        Contains("M-10", 0.5)
-        Contains("M-22", 0.5)
+        Contains("M-20220130T183728-4", 1.0 / 3)
+        Contains("M-20220117T170733-1", 0.5)
+        Contains("M-20220125T063355-6", 0.5)
     }
 
     Entry {
-        id = "M-34"
+        id = "M-20220130T183728-3"
         title = "Rakakun"
         ValidatorSuppress("dah-entry-no-consumed")
 
-        Contains("M-35", 1.0 / 3)
+        Contains("M-20220130T183728-4", 1.0 / 3)
     }
 
     Entry {
         id = "M-VGMDB-AR-15361"
         title = "Inori Minase" // generated(fill_music_metadata.dart v0.1.1)
 
-        Contains("M-9", 1.0 / 5)
-        Contains("M-44", 1.0 / 4)
+        Contains("M-20220116T062502", 1.0 / 5)
+        Contains("M-20220211T055120", 1.0 / 4)
 
         Contains(MusicVocalImageContainFactor) {
             Contains("M-VGMDB-AL-54418-1")
@@ -48,7 +49,7 @@ fun DSLScope.CommonArtists() {
         id = "M-VGMDB-AR-15350"
         title = "M·A·O" // generated(fill_music_metadata.dart v0.1.1)
 
-        Contains("M-44", 1.0 / 4)
+        Contains("M-20220211T055120", 1.0 / 4)
         Contains(MusicVocalImageContainFactor) {
             Contains("M-VGMDB-AL-63666")
         }
@@ -58,7 +59,7 @@ fun DSLScope.CommonArtists() {
         id = "M-VGMDB-AR-16380"
         title = "Rie Takahashi" // generated(fill_music_metadata.dart v0.1.1)
 
-        Contains("M-44", 1.0 / 4)
+        Contains("M-20220211T055120", 1.0 / 4)
 
         Contains(MusicVocalImageContainFactor) {
             Contains("M-VGMDB-AL-53719-1")
@@ -69,8 +70,8 @@ fun DSLScope.CommonArtists() {
         id = "M-VGMDB-AR-15998"
         title = "Ari Ozawa" // generated(fill_music_metadata.dart v0.1.1)
 
-        Contains("M-13", 1.0 / 2)
-        Contains("M-44", 1.0 / 4)
+        Contains("M-20220117T170733-4", 1.0 / 2)
+        Contains("M-20220211T055120", 1.0 / 4)
 
         Contains(MusicVocalImageContainFactor) {
             Contains("M-VGMDB-AL-53719-1", 0.5)
@@ -82,8 +83,8 @@ fun DSLScope.CommonArtists() {
         id = "M-VGMDB-AR-12726"
         title = "Ayane Sakura" // generated(fill_music_metadata.dart v0.1.1)
 
-        Contains("M-9", 1.0 / 5)
-        Contains("M-18", 1.0 / 4)
+        Contains("M-20220116T062502", 1.0 / 5)
+        Contains("M-20220125T063355-2", 1.0 / 4)
 
         Contains(MusicVocalImageContainFactor) {
             Contains("M-VGMDB-AL-82284", 1.0 / 5.0)
@@ -94,21 +95,21 @@ fun DSLScope.CommonArtists() {
         id = "M-VGMDB-AR-13211"
         title = "Risa Taneda" // generated(fill_music_metadata.dart v0.1.1)
 
-        Contains("M-9", 1.0 / 5)
+        Contains("M-20220116T062502", 1.0 / 5)
     }
 
     Entry {
         id = "M-VGMDB-AR-8874"
         title = "Satomi Sato" // generated(fill_music_metadata.dart v0.1.1)
 
-        Contains("M-9", 1.0 / 5)
+        Contains("M-20220116T062502", 1.0 / 5)
     }
 
     Entry {
         id = "M-VGMDB-AR-13289"
         title = "Maaya Uchida" // generated(fill_music_metadata.dart v0.1.1)
 
-        Contains("M-9", 1.0 / 5)
+        Contains("M-20220116T062502", 1.0 / 5)
     }
 
     Entry {
@@ -265,8 +266,8 @@ fun DSLScope.CommonArtists() {
 
             // colorful remixes
             Contains(0.5) {
-                Contains("M-7")
-                Contains("M-8")
+                Contains("M-20220113T184042-3")
+                Contains("M-20220113T184042-4")
             }
 
             Entry {
@@ -291,8 +292,8 @@ fun DSLScope.CommonArtists() {
                     title = "カラフル" // generated(fill_music_metadata.dart v0.1.1)
                     Music(0.5)
 
-                    Remix("M-7")
-                    Remix("M-8")
+                    Remix("M-20220113T184042-3")
+                    Remix("M-20220113T184042-4")
                 }
             }
 
@@ -325,13 +326,13 @@ fun DSLScope.CommonArtists() {
     }
 
     Entry {
-        id = "M-6"
+        id = "M-20220113T184042-2"
         title = "tamame"
         ValidatorSuppress("dah-entry-no-consumed")
 
         Contains(0.5) {
             Entry {
-                id = "M-8"
+                id = "M-20220113T184042-4"
                 title = "Colorful (tamame's apostate remix)"
 
                 // Length source: https://osu.ppy.sh/beatmapsets/866938#osu/1812393
@@ -340,7 +341,7 @@ fun DSLScope.CommonArtists() {
             }
 
             Entry {
-                id = "M-47"
+                id = "M-20220317T064137-3"
                 title = "Tamame - Ebb and Flow (5 years after remix)"
 
                 // Length source: https://osu.ppy.sh/beatmapsets/163756#osu/398882
@@ -378,7 +379,7 @@ fun DSLScope.CommonArtists() {
                     MusicConsumedProgress("4:17") // generated(fill_music_metadata.dart v0.1.1)
                     title = "ebb and flow" // generated(fill_music_metadata.dart v0.1.1)
                     Music(0.35)
-                    Remix("M-47")
+                    Remix("M-20220317T064137-3")
                 }
 
                 SubIDEntry("3") {
@@ -389,7 +390,7 @@ fun DSLScope.CommonArtists() {
             }
 
             Contains(0.5) {
-                Contains("M-47")
+                Contains("M-20220317T064137-3")
             }
         }
     }
@@ -493,8 +494,8 @@ fun DSLScope.CommonArtists() {
         id = "M-VGMDB-AR-18208"
         title = "Yuuki Takada" // generated(fill_music_metadata.dart v0.1.1)
 
-        Contains("M-46", 0.25)
-        Contains("M-17", 1.0 / 9.0)
+        Contains("M-20220317T064137-2", 0.25)
+        Contains("M-20220125T063355-1", 1.0 / 9.0)
         Contains(MusicVocalImageContainFactor) {
             Contains("M-VGMDB-AL-75344-4", 1.0 / 3.0)
         }
@@ -504,30 +505,30 @@ fun DSLScope.CommonArtists() {
         id = "M-VGMDB-AR-18231"
         title = "Megumi Yamaguchi" // generated(fill_music_metadata.dart v0.1.1)
 
-        Contains("M-46", 0.25)
+        Contains("M-20220317T064137-2", 0.25)
     }
 
     Entry {
         id = "M-VGMDB-AR-16233"
         title = "Megumi Toda" // generated(fill_music_metadata.dart v0.1.1)
 
-        Contains("M-46", 0.25)
+        Contains("M-20220317T064137-2", 0.25)
     }
 
     Entry {
         id = "M-VGMDB-AR-18205"
         title = "Ayumi Takeo" // generated(fill_music_metadata.dart v0.1.1)
 
-        Contains("M-46", 0.25)
+        Contains("M-20220317T064137-2", 0.25)
     }
 
     Entry {
-        id = "M-36"
+        id = "M-20220130T185336-1"
         title = "Will Stetson"
         ValidatorSuppress("dah-entry-no-consumed")
 
-        Contains("M-37", 0.3)
-        Contains("M-45", 0.45)
+        Contains("M-20220130T185336-2", 0.3)
+        Contains("M-20220317T064137-1", 0.45)
     }
 
     Entry {
@@ -604,7 +605,7 @@ fun DSLScope.CommonArtists() {
         id = "M-VGMDB-AR-10934"
         title = "Ai Kayano" // generated(fill_music_metadata.dart v0.1.1)
 
-        Contains("M-23", 1.0 / 4.0)
+        Contains("M-20220125T063355-7", 1.0 / 4.0)
         AKMEraPart1(0.05)
         AKMEraPart2(0.1)
         AKMEraPart2(0.05)
@@ -628,17 +629,17 @@ fun DSLScope.CommonArtists() {
                 }
             }
 
-            Contains("M-10", 0.5)
-            Contains("M-11", 0.5)
+            Contains("M-20220117T170733-1", 0.5)
+            Contains("M-20220117T170733-2", 0.5)
         }
     }
 
     Entry {
-        id = "M-12"
+        id = "M-20220117T170733-3"
         title = "kamaboko"
         ValidatorSuppress("dah-entry-no-consumed")
 
-        Contains("M-11", 0.5)
+        Contains("M-20220117T170733-2", 0.5)
     }
 
     Entry {
@@ -696,7 +697,7 @@ fun DSLScope.CommonArtists() {
 
         // le cat va
         Contains(MusicVocalImageContainFactor) {
-            Contains("M-18", 1.0 / 4.0)
+            Contains("M-20220125T063355-2", 1.0 / 4.0)
             Contains("M-VGMDB-AR-32295", 1.0 / 51.0)
         }
     }
@@ -707,7 +708,7 @@ fun DSLScope.CommonArtists() {
 
         // chao e co gai hoan tinh
         Contains(MusicVocalImageContainFactor) {
-            Contains("M-20", 1.0 / 4.0)
+            Contains("M-20220125T063355-4", 1.0 / 4.0)
         }
     }
 
@@ -835,42 +836,42 @@ fun DSLScope.CommonArtists() {
         title = "kemu" // generated(fill_music_metadata.dart v0.1.1)
 
         Contains("M-MAL-36631")
-        Contains("M-41", 0.5)
-        Contains("M-43", 0.25)
+        Contains("M-20220205T023322-1", 0.5)
+        Contains("M-20220205T023322-3", 0.25)
     }
 
     Entry {
         id = "M-VGMDB-AR-4276"
         title = "yuiko" // generated(fill_music_metadata.dart v0.1.1)
 
-        Contains("M-41", 0.5)
+        Contains("M-20220205T023322-1", 0.5)
 
         // backing vocal for akogare future sign (piano arrange ver.)
         Contains("M-VGMDB-AL-86622-2", 0.05)
     }
 
     Entry {
-        id = "M-42"
+        id = "M-20220205T023322-2"
         title = "H△G"
         ValidatorSuppress("dah-entry-no-consumed")
 
-        Contains("M-43", 0.75)
+        Contains("M-20220205T023322-3", 0.75)
 
         Entry {
-            id = "M-63"
+            id = "M-20220818T163913-1"
             title = "Everlasting Night of Teenage Girls"
             ValidatorSuppress("dah-entry-no-consumed")
 
             // Length source: https://open.spotify.com/album/2ztJCuDBki1rNOEi2TrH2W
             Entry {
-                id = "M-64"
+                id = "M-20220818T163913-2"
                 title = "Shoujotachi no Owaranai Yoru"
                 MusicConsumedProgress("4:08") // impl_overridden
                 Music(0.6)
             }
 
             Entry {
-                id = "M-65"
+                id = "M-20220818T163913-3"
                 title = "Colorful"
                 // [prismatic]
                 // 1-2 1-2 1-2 1-2
@@ -883,11 +884,11 @@ fun DSLScope.CommonArtists() {
     }
 
     Entry {
-        id = "M-44"
+        id = "M-20220211T055120"
         title = "Chiho"
         ValidatorSuppress("dah-entry-no-consumed")
 
-        Contains("M-42", 0.5)
+        Contains("M-20220205T023322-2", 0.5)
     }
 
     Entry {
@@ -904,7 +905,7 @@ fun DSLScope.CommonArtists() {
         title = "Yuka Iwahashi" // generated(fill_music_metadata.dart v0.1.1)
 
         // t̷̤̀h̵̙̰̒ẽ̷̥̋ ̶̺͔̌͘h̴̡̜̐̎o̴̥͉͒̊n̴͕̈́̎ǰ̷̢͜ő̸̞͎̈ủ̵͔ͅ ̴͔̘̏k̸̛͉̉a̵̯̣͑͆ŝ̴̝u̶͉̠̎̂m̵̞͛i̷͙͉͋ ̴̨̥̓ḯ̵͖̺n̷̲̉̌c̷̪̓i̴̢͎̋d̵̬͛e̸̗̓ń̷͓̤͠t̷̮̭̄̐
-        Contains("M-50", 1.0 / 9.0)
+        Contains("M-20220319T061727", 1.0 / 9.0)
         Contains("M-VGMDB-AR-30829", 1.0 / 6.0)
     }
 
@@ -960,7 +961,7 @@ fun DSLScope.CommonArtists() {
         // rst shills are truly on another level of stupidity
         Contains(0.5) {
             Entry {
-                id = "M-60"
+                id = "M-20220623T082620"
                 title = "Cobalt Memories (Amane Makino ver.)"
                 // https://www.youtube.com/watch?v=_IWGubxbp1k
 
@@ -986,7 +987,7 @@ fun DSLScope.CommonArtists() {
         AKMEraPart2(0.35)
         AKMEraPart3(0.3)
         // (not the whole cricri unit)
-        Contains("M-23", 0.25)
+        Contains("M-20220125T063355-7", 0.25)
 
         Contains(MusicVocalImageContainFactor) {
             Contains("M-VGMDB-AL-95314")
@@ -1008,7 +1009,7 @@ fun DSLScope.CommonArtists() {
         AKMEraPart3(0.3)
         // additional 0.25 because akm is sung by rosia and jacklyn
         // (not the whole cricri unit)
-        Contains("M-23", 0.25)
+        Contains("M-20220125T063355-7", 0.25)
         // 765
         Contains("M-VGMDB-AR-32295", 1.0 / 51.0)
 

--- a/impl/src/main/kotlin/com/dah/nrs/D4DJ.kt
+++ b/impl/src/main/kotlin/com/dah/nrs/D4DJ.kt
@@ -26,7 +26,7 @@ fun DSLScope.D4DJ() {
         }
 
         Entry {
-            id = "M-66"
+            id = "M-20220823T115611"
             title = "Happy Around!"
             ValidatorSuppress("dah-entry-no-consumed")
 

--- a/impl/src/main/kotlin/com/dah/nrs/GakkouGurashi.kt
+++ b/impl/src/main/kotlin/com/dah/nrs/GakkouGurashi.kt
@@ -25,7 +25,7 @@ fun DSLScope.GakkouGurashi() {
         }
 
         Entry {
-            id = "M-44"
+            id = "M-20220211T055120"
             title = "Gakuen Seikatsubu"
             ValidatorSuppress("dah-entry-no-consumed")
 

--- a/impl/src/main/kotlin/com/dah/nrs/GochiUsa.kt
+++ b/impl/src/main/kotlin/com/dah/nrs/GochiUsa.kt
@@ -28,7 +28,7 @@ fun DSLScope.GochiUsa() {
         }
 
         Entry {
-            id = "M-9"
+            id = "M-20220116T062502"
             title = "Petit Rabbit's"
             ValidatorSuppress("dah-entry-no-consumed")
 

--- a/impl/src/main/kotlin/com/dah/nrs/Irodori.kt
+++ b/impl/src/main/kotlin/com/dah/nrs/Irodori.kt
@@ -61,14 +61,14 @@ fun DSLScope.Irodori() {
         }
 
         Entry {
-            id = "M-29"
+            id = "M-20220130T165739-2"
             title = "Maware! GO! GO! CHUNITHM"
             ValidatorSuppress("dah-entry-no-consumed")
 
             Visual(VisualKind.AlbumArt, 0.35, 0.4)
 
             Entry {
-                id = "M-30"
+                id = "M-20220130T165739-3"
                 title = "Bokura no Freedom DiVE↓"
 
                 Visual(VisualKind.AlbumArt, 0.4, 0.45)
@@ -79,7 +79,7 @@ fun DSLScope.Irodori() {
             }
 
             Entry {
-                id = "M-31"
+                id = "M-20220130T165739-4"
                 title = "Zero kara hajimeru Brain Power"
 
                 // Length source: https://www.youtube.com/watch?v=iRNH_wF7nrc
@@ -89,14 +89,14 @@ fun DSLScope.Irodori() {
         }
 
         Entry {
-            id = "M-26"
+            id = "M-20220130T165739-1"
             title = "Irodorimidori"
             ValidatorSuppress("dah-entry-no-consumed")
 
             // times 0.6 because they are all covers
             Contains(MusicVocalImageContainFactor) {
                 Contains("M-VGMDB-AL-93299")
-                Contains("M-29")
+                Contains("M-20220130T165739-2")
             }
         }
     }

--- a/impl/src/main/kotlin/com/dah/nrs/IsekaiQuartet.kt
+++ b/impl/src/main/kotlin/com/dah/nrs/IsekaiQuartet.kt
@@ -5,7 +5,7 @@ import com.dah.nrs.exts.*
 
 fun DSLScope.IsekaiQuartet() {
     Entry {
-        id = "F-1"
+        id = "F-20220823T083245"
         title = "Isekai Quartet"
 
         Entry {

--- a/impl/src/main/kotlin/com/dah/nrs/JMetal.kt
+++ b/impl/src/main/kotlin/com/dah/nrs/JMetal.kt
@@ -48,7 +48,7 @@ fun DSLScope.JMetal() {
             }
 
             contributors["M-VGMDB-AL-43320"] = 0.4
-            contributors["M-64"] = 0.6
+            contributors["M-20220818T163913-2"] = 0.6
         }
 
         Entry {

--- a/impl/src/main/kotlin/com/dah/nrs/Kano.kt
+++ b/impl/src/main/kotlin/com/dah/nrs/Kano.kt
@@ -179,7 +179,7 @@ fun DSLScope.Kano() {
             Entry {
                 // from the album "Colorful Wonder Note", track number 8
                 // and yes this is from osugame too
-                id = "M-24"
+                id = "M-20220130T032649"
                 title = "Kimiiro Hanabi -album version-"
 
                 // Length source: https://osu.ppy.sh/beatmapsets/514772#osu/1093352
@@ -269,7 +269,7 @@ fun DSLScope.Kano() {
 
             // oh except for this, i forgor
             Entry {
-                id = "M-49"
+                id = "M-20220317T064137-5"
                 title = "Sore wa Kitto Natsudatta"
 
                 Visual(VisualKind.AnimatedMV, 0.35, 0.7)

--- a/impl/src/main/kotlin/com/dah/nrs/LapisReLights.kt
+++ b/impl/src/main/kotlin/com/dah/nrs/LapisReLights.kt
@@ -32,7 +32,7 @@ fun DSLScope.LapisReLights() {
         }
 
         Entry {
-            id = "M-51"
+            id = "M-20220324T055811"
             title = "LiGHTs"
             ValidatorSuppress("dah-entry-no-consumed")
 

--- a/impl/src/main/kotlin/com/dah/nrs/LoveLive.kt
+++ b/impl/src/main/kotlin/com/dah/nrs/LoveLive.kt
@@ -529,8 +529,8 @@ fun DSLScope.LoveLive() {
         PADS(5, Emotion.CU) {
             contributors["A-MAL-40879"] = 0.7
             contributors["M-MAL-36631-6"] = 0.15
-            contributors["M-41"] = 0.075
-            contributors["M-43"] = 0.05
+            contributors["M-20220205T023322-1"] = 0.075
+            contributors["M-20220205T023322-3"] = 0.05
             contributors["M-VGMDB-AL-89290-6"] = 0.025
         }
 
@@ -655,7 +655,7 @@ fun DSLScope.LoveLive() {
     }
 
     Entry {
-        id = "M-45"
+        id = "M-20220317T064137-1"
         title = "Snow Halation (feat. BeasttrollMC)"
 
         Meme(0.03, 6)

--- a/impl/src/main/kotlin/com/dah/nrs/MadokaMagica.kt
+++ b/impl/src/main/kotlin/com/dah/nrs/MadokaMagica.kt
@@ -271,13 +271,13 @@ fun DSLScope.MadokaMagica() {
     }
 
     Entry {
-        id = "M-5"
+        id = "M-20220113T184042-1"
         title = "Magibeat"
         ValidatorSuppress("dah-entry-no-consumed")
 
         Contains(0.5) {
             Entry {
-                id = "M-7"
+                id = "M-20220113T184042-3"
                 title = "Colorful - Magibeat Remix"
 
                 // Length source: https://www.nicovideo.jp/watch/sm22151925

--- a/impl/src/main/kotlin/com/dah/nrs/NRSImplMain.kt
+++ b/impl/src/main/kotlin/com/dah/nrs/NRSImplMain.kt
@@ -17,14 +17,6 @@ import com.dah.nrs.seasonal.Fall2022
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
-// custom id counters:
-// M-68
-// A-1
-// L-1
-// G-1
-// F-2
-// O-7
-
 fun main() =
     generate {
         CommonArtists()

--- a/impl/src/main/kotlin/com/dah/nrs/NewGame.kt
+++ b/impl/src/main/kotlin/com/dah/nrs/NewGame.kt
@@ -60,7 +60,7 @@ fun DSLScope.NewGame() {
         }
 
         Entry {
-            id = "M-46"
+            id = "M-20220317T064137-2"
             title = "fourfolium"
             ValidatorSuppress("dah-entry-no-consumed")
 

--- a/impl/src/main/kotlin/com/dah/nrs/OneRoom.kt
+++ b/impl/src/main/kotlin/com/dah/nrs/OneRoom.kt
@@ -35,7 +35,7 @@ fun DSLScope.OneRoom() {
                 // H A R U M A C H I   K U R O B A A A
                 Music(0.35)
                 OsuSong(personal = 0.6, community = 0.8)
-                Remix("M-37")
+                Remix("M-20220130T185336-2")
             }
         }
 
@@ -56,7 +56,7 @@ fun DSLScope.OneRoom() {
     }
 
     Entry {
-        id = "M-37"
+        id = "M-20220130T185336-2"
         title = "Harumachi Clover (Swing Arrangement) [Dictate Edit]"
 
         // Length source: https://www.youtube.com/watch?v=2OfJYisHbkI

--- a/impl/src/main/kotlin/com/dah/nrs/OnsenMusume.kt
+++ b/impl/src/main/kotlin/com/dah/nrs/OnsenMusume.kt
@@ -24,7 +24,7 @@ fun DSLScope.OnsenMusume() {
         }
 
         Entry {
-            id = "M-17"
+            id = "M-20220125T063355-1"
             title = "SPRiNGS"
             ValidatorSuppress("dah-entry-no-consumed")
 

--- a/impl/src/main/kotlin/com/dah/nrs/OsuGame.kt
+++ b/impl/src/main/kotlin/com/dah/nrs/OsuGame.kt
@@ -34,7 +34,7 @@ fun DSLScope.OsuGame() {
     }
 
     Entry {
-        id = "M-52"
+        id = "M-20220410T181408"
         title = "United (L.A.O.S Remix)"
 
         // we kicked a kid, united

--- a/impl/src/main/kotlin/com/dah/nrs/ReStage.kt
+++ b/impl/src/main/kotlin/com/dah/nrs/ReStage.kt
@@ -582,7 +582,7 @@ fun DSLScope.ReStage() {
         Entry {
             // cri-cri of rst
             // not even close tho
-            id = "M-13"
+            id = "M-20220117T170733-4"
             title = "ortensia"
 
             // # The ortensia incident
@@ -673,7 +673,7 @@ fun DSLScope.ReStage() {
         }
 
         Entry {
-            id = "M-14"
+            id = "M-20220117T170733-5"
             title = "Stellamaris"
             ValidatorSuppress("dah-entry-no-consumed")
 
@@ -684,7 +684,7 @@ fun DSLScope.ReStage() {
         }
 
         Entry {
-            id = "M-15"
+            id = "M-20220117T170733-6"
             title = "TROIS ANGES"
             ValidatorSuppress("dah-entry-no-consumed")
 
@@ -707,7 +707,7 @@ fun DSLScope.ReStage() {
         }
 
         Entry {
-            id = "M-16"
+            id = "M-20220117T170733-7"
             title = "Tetrarkhia"
             ValidatorSuppress("dah-entry-no-consumed")
 
@@ -886,7 +886,7 @@ fun DSLScope.ReStage() {
         }
 
         Entry {
-            id = "M-48"
+            id = "M-20220317T064137-4"
             title = "Re:STAGE! ALL IDOL"
             ValidatorSuppress("dah-entry-no-consumed")
 
@@ -950,12 +950,12 @@ fun DSLScope.ReStage() {
         }
 
         // r/osuplace stuff
-        KilledBy("M-52", potential = 0.4, effect = 0.9) {
+        KilledBy("M-20220410T181408", potential = 0.4, effect = 0.9) {
             contributors["A-MAL-38009"] = 0.8
             contributors["GF-VGMDB-7059"] = 0.2
         }
 
-        KilledBy("O-1", potential = 0.2, effect = 0.75) {
+        KilledBy("O-20220415T155427", potential = 0.2, effect = 0.75) {
             contributors["A-MAL-38009"] = 0.8
             contributors["GF-VGMDB-7059"] = 0.2
         }
@@ -1000,7 +1000,7 @@ fun DSLScope.ReStage() {
     }
 
     Entry {
-        id = "M-53"
+        id = "M-20220507T131634"
         title = "Re:STAGE! Songs Compilation"
         // kek 69 min song comp
         // TODO: add the 48 songs here

--- a/impl/src/main/kotlin/com/dah/nrs/SB69.kt
+++ b/impl/src/main/kotlin/com/dah/nrs/SB69.kt
@@ -732,7 +732,7 @@ fun DSLScope.SB69() {
         }
 
         Entry {
-            id = "M-21"
+            id = "M-20220125T063355-5"
             title = "BUD VIRGIN LOGIC"
             ValidatorSuppress("dah-entry-no-consumed")
 

--- a/impl/src/main/kotlin/com/dah/nrs/SB69.kt
+++ b/impl/src/main/kotlin/com/dah/nrs/SB69.kt
@@ -74,7 +74,7 @@ fun DSLScope.SB69() {
             contributors["G-VGMDB-8429"] = 0.2
         }
 
-        KilledBy("O-1", potential = 0.2, effect = 0.75) {
+        KilledBy("O-20220415T155427", potential = 0.2, effect = 0.75) {
             contributors["A-MAL-27441"] = 0.2
             contributors["A-MAL-32038"] = 0.2
             contributors["A-MAL-40763"] = 0.2
@@ -150,7 +150,7 @@ fun DSLScope.SB69() {
             // the screentime thing
             // mashu mp farm got fucked by the existence of the cat
             // and pmgc
-            KilledBy("M-18", potential = 0.75, effect = 0.75)
+            KilledBy("M-20220125T063355-2", potential = 0.75, effect = 0.75)
             Visual(VisualKind.Animated, 0.65, 0.4)
 
             AnimeProgressOld(Boredom.Completed, 12)
@@ -242,7 +242,7 @@ fun DSLScope.SB69() {
                 MusicConsumedProgress("4:17") // generated(fill_music_metadata.dart v0.1.1)
                 FesALiveMusic(0.25)
 
-                Remix("M-22")
+                Remix("M-20220125T063355-6")
             }
 
             SubIDEntry("2") {
@@ -379,7 +379,7 @@ fun DSLScope.SB69() {
                 // hahahahahaaha the howan tinh song
                 FesALiveMusic(0.25)
                 Meme(0.01, numDays("2022-04-01"))
-                Remix("M-62")
+                Remix("M-20220702T030659")
             }
 
             SubIDEntry("3") {
@@ -390,7 +390,7 @@ fun DSLScope.SB69() {
         }
 
         Entry {
-            id = "M-62"
+            id = "M-20220702T030659"
             title = "Kimi no Rhapsody (DJ DEVILMINTKIRYU Remix)"
             // aka hoantinh theme song
 
@@ -687,14 +687,14 @@ fun DSLScope.SB69() {
         }
 
         Entry {
-            id = "M-18"
+            id = "M-20220125T063355-2"
             title = "Plasmagica"
             ValidatorSuppress("dah-entry-no-consumed")
 
             Contains(MusicVocalImageContainFactor) {
                 Contains("M-VGMDB-AL-94913")
                 Contains("M-VGMDB-AL-51276")
-                Contains("M-22", 0.5)
+                Contains("M-20220125T063355-6", 0.5)
                 Contains("M-VGMDB-AL-51706")
                 Contains("M-VGMDB-AL-61217")
                 Contains("M-VGMDB-AL-61981")
@@ -707,7 +707,7 @@ fun DSLScope.SB69() {
         }
 
         Entry {
-            id = "M-19"
+            id = "M-20220125T063355-3"
             title = "Tsurezurenaru Ayatsuri Mugenan"
             ValidatorSuppress("dah-entry-no-consumed")
 
@@ -717,7 +717,7 @@ fun DSLScope.SB69() {
         }
 
         Entry {
-            id = "M-20"
+            id = "M-20220125T063355-4"
             title = "Mashumairesh!!"
             ValidatorSuppress("dah-entry-no-consumed")
 
@@ -727,7 +727,7 @@ fun DSLScope.SB69() {
                 Contains("M-VGMDB-AL-104341-1", 0.5)
                 Contains("M-VGMDB-AL-104341-2", 1.0)
                 Contains("M-VGMDB-AL-104267-8", 1.0)
-                Contains("M-62", 0.5)
+                Contains("M-20220702T030659", 0.5)
             }
         }
 
@@ -743,7 +743,7 @@ fun DSLScope.SB69() {
         }
 
         Entry {
-            id = "M-23"
+            id = "M-20220125T063355-7"
             title = "Criticrista"
             ValidatorSuppress("dah-entry-no-consumed")
 
@@ -768,7 +768,7 @@ fun DSLScope.SB69() {
 
     // the famous speed-finger control map
     Entry {
-        id = "M-22"
+        id = "M-20220125T063355-6"
         title = "Seishun wa Non-Stop! (Asterisk DnB Remix)"
 
         // Length source: https://soundcloud.com/asteriskbtlg/5315yun-w4-n0n-st0pasterisk-dnb-remix

--- a/impl/src/main/kotlin/com/dah/nrs/Saekano.kt
+++ b/impl/src/main/kotlin/com/dah/nrs/Saekano.kt
@@ -86,7 +86,7 @@ fun DSLScope.Saekano() {
     }
 
     Entry {
-        id = "M-10"
+        id = "M-20220117T170733-1"
         title = "Colorful. (Asterisk DnB Remix)"
 
         // Length source: https://osu.ppy.sh/beatmapsets/299454
@@ -95,7 +95,7 @@ fun DSLScope.Saekano() {
     }
 
     Entry {
-        id = "M-11"
+        id = "M-20220117T170733-2"
         title = "Colorful. (kamaboko remix)"
 
         // Length source: https://www.youtube.com/watch?v=FkUIAeBcVUw

--- a/impl/src/main/kotlin/com/dah/nrs/SelePro.kt
+++ b/impl/src/main/kotlin/com/dah/nrs/SelePro.kt
@@ -28,7 +28,7 @@ fun DSLScope.SelePro() {
         }
 
         Entry {
-            id = "M-50"
+            id = "M-20220319T061727"
             title = "9-tie"
             ValidatorSuppress("dah-entry-no-consumed")
 

--- a/impl/src/main/kotlin/com/dah/nrs/Vocaloid.kt
+++ b/impl/src/main/kotlin/com/dah/nrs/Vocaloid.kt
@@ -26,13 +26,13 @@ fun DSLScope.Vocaloid() {
             // Length source: https://www.nicovideo.jp/watch/sm18198019
             Music(0.425)
             MusicConsumedProgress("4:32") // impl_overridden
-            Remix("M-41")
-            Remix("M-43")
+            Remix("M-20220205T023322-1")
+            Remix("M-20220205T023322-3")
         }
     }
 
     Entry {
-        id = "M-41"
+        id = "M-20220205T023322-1"
         title = "Chikyuu Saigo no Kokuhaku wo (yuikonnu)"
 
         // yuiko version is probably the best, music-wise
@@ -42,7 +42,7 @@ fun DSLScope.Vocaloid() {
     }
 
     Entry {
-        id = "M-43"
+        id = "M-20220205T023322-3"
         title = "Chikyuu Saigo no Kokuhaku wo (HAG)"
 
         // quite good, but they didn't keep the orig. inst.

--- a/impl/src/main/kotlin/com/dah/nrs/WorldWitches.kt
+++ b/impl/src/main/kotlin/com/dah/nrs/WorldWitches.kt
@@ -164,13 +164,13 @@ fun DSLScope.WorldWitches() {
                 MusicConsumedProgress("4:09") // generated(fill_music_metadata.dart v0.1.1)
                 title = "Yakusoku no Sora e ~Watashi no Ita Basho~" // generated(fill_music_metadata.dart v0.1.1)
                 Music(0.4)
-                Remix("M-67")
+                Remix("M-20221009T085407")
             }
         }
     }
 
     Entry {
-        id = "M-67"
+        id = "M-20221009T085407"
         title = "- 約束の空へ ～私のいた場所～(Soleily Remix)"
 
         Music(0.6)

--- a/impl/src/main/kotlin/com/dah/nrs/meme/MVLiterature.kt
+++ b/impl/src/main/kotlin/com/dah/nrs/meme/MVLiterature.kt
@@ -9,7 +9,7 @@ fun DSLScope.MVLiterature() {
     // based rst turning literally everything into a meme
     // (those texts getting their own entries is a way to nerf rst/sb69 btw)
     Entry {
-        id = "O-2"
+        id = "O-20220702T030659-1"
         title = "Người lái đò Sông Đà"
 
         // the river analogy states that the love live franchise is our opponents/enemies
@@ -18,7 +18,7 @@ fun DSLScope.MVLiterature() {
     }
 
     Entry {
-        id = "O-3"
+        id = "O-20220702T030659-2"
         title = "Vợ chồng A Phủ"
 
         // there are several analogies for this
@@ -38,7 +38,7 @@ fun DSLScope.MVLiterature() {
     }
 
     Entry {
-        id = "O-4"
+        id = "O-20220702T030659-3"
         title = "Chiếc thuyền ngoài xa"
         // https://vi.wikipedia.org/wiki/Chi%E1%BA%BFc_thuy%E1%BB%81n_ngo%C3%A0i_xa
 

--- a/impl/src/main/kotlin/com/dah/nrs/meme/Method.kt
+++ b/impl/src/main/kotlin/com/dah/nrs/meme/Method.kt
@@ -6,7 +6,7 @@ import com.dah.nrs.exts.*
 
 fun DSLScope.Method() {
     Entry {
-        id = "O-1"
+        id = "O-20220415T155427"
         title = "Kizuna Method"
         bestGirl = "method" // impl_overridden
 

--- a/impl/src/main/kotlin/com/dah/nrs/meme/PostModern.kt
+++ b/impl/src/main/kotlin/com/dah/nrs/meme/PostModern.kt
@@ -12,13 +12,13 @@ fun AcceptImpact.PostModernMeme(strength: Double, block: DSLImpact.() -> Unit = 
 fun DSLScope.PostModern() {
     // ngl these names are cool as fuck
     Entry {
-        id = "O-5"
+        id = "O-20221003T175501-1"
         title = "Neo-Autism Party"
         PostModernMeme(0.3)
     }
 
     Entry {
-        id = "O-6"
+        id = "O-20221003T175501-2"
         title = "Nyumber One! Zettai Saikyou! Party"
         PostModernMeme(0.5)
     }

--- a/validator/src/main/kotlin/com/dah/nrs/Validator.kt
+++ b/validator/src/main/kotlin/com/dah/nrs/Validator.kt
@@ -60,6 +60,7 @@ fun main() {
         dah_no_progress(data),
         dah_invalid_id(data),
         dah_no_title(data),
+        dah_check_custom_id(data),
     )) {
         rule.run()
     }

--- a/validator/src/main/kotlin/com/dah/nrs/rules/dah_check_custom_id.kt
+++ b/validator/src/main/kotlin/com/dah/nrs/rules/dah_check_custom_id.kt
@@ -1,0 +1,53 @@
+package com.dah.nrs.rules
+
+import com.dah.nrs.Data
+import com.dah.nrs.ValidationRule
+import java.lang.StringBuilder
+import java.time.LocalDate
+import java.time.format.DateTimeParseException
+
+class dah_check_custom_id(data: Data) : ValidationRule(data) {
+    override fun run() {
+        entries.keys.mapNotNull { it.split('-').getOrNull(1) }
+            .filter { it[0].isDigit() }
+            .forEach {
+                val warn = { warn("Invalid custom ID timestamp: $it") }
+                val tokens = it.split('T')
+                if(tokens.size != 2) {
+                    warn()
+                    return@forEach
+                }
+
+                val (dateToken, timeToken) = tokens
+                if(!checkDateToken(dateToken) || !checkTimeToken(timeToken)) {
+                    warn()
+                    return@forEach
+                }
+            }
+    }
+
+    private fun checkDateToken(dateToken: String): Boolean {
+        if(dateToken.length != 8 || dateToken.any { !it.isDigit() }) {
+            return false
+        }
+
+        val dateStr = StringBuilder(dateToken)
+        dateStr.insert(6, '-')
+        dateStr.insert(4, '-')
+        return try {
+            LocalDate.parse(dateStr)
+            true
+        } catch (ex: DateTimeParseException) {
+            false
+        }
+    }
+
+    private fun checkTimeToken(timeToken: String): Boolean {
+        if(timeToken.length != 6 || timeToken.any { !it.isDigit() }) {
+            return false
+        }
+
+        val (hr, mn, sec) = timeToken.windowed(2, 2)
+        return (hr.toInt() in 0 .. 23) && (mn.toInt() in 0 .. 59) && (sec.toInt() in 0 .. 59)
+    }
+}


### PR DESCRIPTION
This PR modify ID of all entries with custom ID to be timestamp-based, implementing the `DAH_entry_id_impl` extension in [this](https://github.com/ngoduyanh/nrs/tree/9-dah_entry_id-using-timestamps-to-stable-custom-ids) branch of the NRS spec.